### PR TITLE
 Authorisation removed from course index page

### DIFF
--- a/app/controllers/courses_controller.rb
+++ b/app/controllers/courses_controller.rb
@@ -1,5 +1,9 @@
 class CoursesController < ApplicationController
   before_action :set_course, only: [:show, :edit, :destroy]
+  skip_before_action :authenticate_user!, only: :index
+
+
+
 
   def index
     @courses = Course.all


### PR DESCRIPTION
1 Line of code :  skip_before_action :authenticate_user!, only: :index 
So that users don't need to authenticate to see homepage offers. 
